### PR TITLE
WIP: Logitech

### DIFF
--- a/prog/usb-flasher/logitech-usb-flash.py
+++ b/prog/usb-flasher/logitech-usb-flash.py
@@ -13,7 +13,7 @@ def crc_update(crc, data):
 
 # Make sure a firmware image path was passed in
 if len(sys.argv) < 3:
-  print "Usage: sudo ./logitech-usb-flash.py [firmware-image.bin] [firmware-image.ihx]"
+  print("Usage: sudo ./logitech-usb-flash.py [firmware-image.bin] [firmware-image.ihx]")
 
 # Compute the CRC of the firmware image
 logging.info("Computing the CRC of the firmware image")

--- a/prog/usb-flasher/unifying.py
+++ b/prog/usb-flasher/unifying.py
@@ -24,8 +24,8 @@ logging.basicConfig(level=logging.INFO, format='[%(asctime)s.%(msecs)03d]  %(mes
 # Check pyusb dependency
 try:
   from usb import core as _usb_core
-except ImportError, ex:
-  print '''
+except ImportError:
+  print('''
 ------------------------------------------
 | PyUSB was not found or is out of date. |
 ------------------------------------------
@@ -33,7 +33,7 @@ except ImportError, ex:
 Please update PyUSB using pip:
 
 sudo pip install -U -I pip && sudo pip install -U -I pyusb
-'''
+''')
   sys.exit(1)
 
 # Sufficiently long timeout for use in a VM

--- a/prog/usb-flasher/usb-flash.py
+++ b/prog/usb-flasher/usb-flash.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 '''
   Copyright (C) 2016 Bastille Networks
 
@@ -25,8 +25,8 @@ logging.basicConfig(level=logging.INFO, format='[%(asctime)s.%(msecs)03d]  %(mes
 # Check pyusb dependency
 try:
   from usb import core as _usb_core
-except ImportError, ex:
-  print '''
+except ImportError as ex:
+  print('''
 ------------------------------------------
 | PyUSB was not found or is out of date. |
 ------------------------------------------
@@ -34,7 +34,7 @@ except ImportError, ex:
 Please update PyUSB using pip:
 
 sudo pip install -U -I pip && sudo pip install -U -I pyusb
-'''
+''')
   sys.exit(1)
 
 # USB timeout sufficiently long for operating in a VM
@@ -42,7 +42,7 @@ usb_timeout = 2500
 
 # Verify that we received a command line argument
 if len(sys.argv) < 2:
-  print 'Usage: ./usb-flash.py path-to-firmware.bin'
+  print('Usage: ./usb-flash.py path-to-firmware.bin')
   quit()
 
 # Read in the firmware
@@ -50,7 +50,7 @@ with open(sys.argv[1], 'rb') as f:
   data = f.read()
 
 # Zero pad the data to a multiple of 512 bytes
-data += '\000' * (512 - len(data) % 512)
+data += b'\000' * (512 - len(data) % 512)
 
 # Find an attached device running CrazyRadio or RFStorm firmware
 logging.info("Looking for a compatible device that can jump to the Nordic bootloader")
@@ -93,7 +93,7 @@ if not dongle:
 
 # Write the data, one page at a time
 logging.info("Writing image to flash")
-page_count = len(data) / 512
+page_count = len(data) // 512
 for page in range(page_count):
 
   # Tell the bootloader that we are going to write a page
@@ -122,8 +122,8 @@ for page in range(page_count):
 
     # Read the block
     dongle.write(0x01, [0x03, block_number], usb_timeout)
-    block_read = array.array('B', dongle.read(0x81, 64, usb_timeout)).tostring()
-    if block_read != data[block_number*64:block_number*64+64]:
+    block_read = dongle.read(0x81, 64, usb_timeout)
+    if block_read != array.array('B', data[block_number*64:block_number*64+64]):
       raise Exception('Verification failed on page {0}, block {1}'.format(page, block))
     block_number += 1
 

--- a/tools/lib/common.py
+++ b/tools/lib/common.py
@@ -17,7 +17,7 @@
 
 
 import logging, argparse
-from nrf24 import *
+from .nrf24 import *
 
 channels = []
 args = None
@@ -30,7 +30,7 @@ def init_args(description):
   global parser
   parser = argparse.ArgumentParser(description,
     formatter_class=lambda prog: argparse.HelpFormatter(prog,max_help_position=50,width=120))
-  parser.add_argument('-c', '--channels', type=int, nargs='+', help='RF channels', default=range(2, 84), metavar='N')
+  parser.add_argument('-c', '--channels', type=int, nargs='+', help='RF channels', default=list(range(2, 84)), metavar='N')
   parser.add_argument('-v', '--verbose', action='store_true', help='Enable verbose output', default=False)
   parser.add_argument('-l', '--lna', action='store_true', help='Enable the LNA (for CrazyRadio PA dongles)', default=False)
   parser.add_argument('-i', '--index', type=int, help='Dongle index', default=0)

--- a/tools/lib/nrf24.py
+++ b/tools/lib/nrf24.py
@@ -21,8 +21,8 @@ import usb, logging
 # Check pyusb dependency
 try:
   from usb import core as _usb_core
-except ImportError, ex:
-  print '''
+except ImportError as ex:
+  print('''
 ------------------------------------------
 | PyUSB was not found or is out of date. |
 ------------------------------------------
@@ -30,7 +30,7 @@ except ImportError, ex:
 Please update PyUSB using pip:
 
 sudo pip install -U -I pip && sudo pip install -U -I pyusb
-'''
+''')
   sys.exit(1)
 
 # USB commands
@@ -65,14 +65,14 @@ class nrf24:
     try:
       self.dongle = list(usb.core.find(idVendor=0x1915, idProduct=0x0102, find_all=True))[index]
       self.dongle.set_configuration()
-    except usb.core.USBError, ex:
+    except usb.core.USBError as ex:
       raise ex
     except:
       raise Exception('Cannot find USB dongle.')
 
   # Put the radio in pseudo-promiscuous mode
   def enter_promiscuous_mode(self, prefix=[]):
-    self.send_usb_command(ENTER_PROMISCUOUS_MODE, [len(prefix)]+map(ord, prefix))
+    self.send_usb_command(ENTER_PROMISCUOUS_MODE, [len(prefix)]+list(map(ord, prefix)))
     self.dongle.read(0x81, 64, timeout=nrf24.usb_timeout)
     if len(prefix) > 0:
       logging.debug('Entered promiscuous mode with address prefix {0}'.
@@ -82,7 +82,7 @@ class nrf24:
 
   # Put the radio in pseudo-promiscuous mode without CRC checking
   def enter_promiscuous_mode_generic(self, prefix=[], rate=RF_RATE_2M, payload_length=32):
-    self.send_usb_command(ENTER_PROMISCUOUS_MODE_GENERIC, [len(prefix), rate, payload_length]+map(ord, prefix))
+    self.send_usb_command(ENTER_PROMISCUOUS_MODE_GENERIC, [len(prefix), rate, payload_length]+list(map(ord, prefix)))
     self.dongle.read(0x81, 64, timeout=nrf24.usb_timeout)
     if len(prefix) > 0:
       logging.debug('Entered generic promiscuous mode with address prefix {0}'.
@@ -92,7 +92,7 @@ class nrf24:
 
   # Put the radio in ESB "sniffer" mode (ESB mode w/o auto-acking)
   def enter_sniffer_mode(self, address):
-    self.send_usb_command(ENTER_SNIFFER_MODE, [len(address)]+map(ord, address))
+    self.send_usb_command(ENTER_SNIFFER_MODE, [len(address)]+list(map(ord, address)))
     self.dongle.read(0x81, 64, timeout=nrf24.usb_timeout)
     logging.debug('Entered sniffer mode with address {0}'.
         format(':'.join('{:02X}'.format(ord(b)) for b in address[::-1])))
@@ -110,19 +110,19 @@ class nrf24:
 
   # Transmit a generic (non-ESB) payload
   def transmit_payload_generic(self, payload, address="\x33\x33\x33\x33\x33"):
-    data = [len(payload), len(address)]+map(ord, payload)+map(ord, address)
+    data = [len(payload), len(address)]+list(map(ord, payload))+list(map(ord, address))
     self.send_usb_command(TRANSMIT_PAYLOAD_GENERIC, data)
     return self.dongle.read(0x81, 64, timeout=nrf24.usb_timeout)[0] > 0
 
   # Transmit an ESB payload
   def transmit_payload(self, payload, timeout=4, retransmits=15):
-    data = [len(payload), timeout, retransmits]+map(ord, payload)
+    data = [len(payload), timeout, retransmits]+list(map(ord, payload))
     self.send_usb_command(TRANSMIT_PAYLOAD, data)
     return self.dongle.read(0x81, 64, timeout=nrf24.usb_timeout)[0] > 0
 
   # Transmit an ESB ACK payload
   def transmit_ack_payload(self, payload):
-    data = [len(payload)]+map(ord, payload)
+    data = [len(payload)]+list(map(ord, payload))
     self.send_usb_command(TRANSMIT_ACK_PAYLOAD, data)
     return self.dongle.read(0x81, 64, timeout=nrf24.usb_timeout)[0] > 0
 

--- a/tools/nrf24-scanner.py
+++ b/tools/nrf24-scanner.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 '''
   Copyright (C) 2016 Bastille Networks
 
@@ -17,7 +17,7 @@
 '''
 
 
-import time, logging
+import codecs, time, logging
 from lib import common
 
 # Parse command line arguments and initialize the radio
@@ -27,7 +27,7 @@ common.parser.add_argument('-d', '--dwell', type=float, help='Dwell time per cha
 common.parse_and_init()
 
 # Parse the prefix addresses
-prefix_address = common.args.prefix.replace(':', '').decode('hex')
+prefix_address = codecs.decode(common.args.prefix.replace(':', ''), 'hex')
 if len(prefix_address) > 5:
   raise Exception('Invalid prefix address: {0}'.format(args.address))
 

--- a/tools/nrf24-sniffer.py
+++ b/tools/nrf24-sniffer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python
 '''
   Copyright (C) 2016 Bastille Networks
 
@@ -17,7 +17,7 @@
 '''
 
 
-import time, logging
+import codecs, time, logging
 from lib import common
 
 # Parse command line arguments and initialize the radio
@@ -25,12 +25,12 @@ common.init_args('./nrf24-sniffer.py')
 common.parser.add_argument('-a', '--address', type=str, help='Address to sniff, following as it changes channels', required=True)
 common.parser.add_argument('-t', '--timeout', type=float, help='Channel timeout, in milliseconds', default=100)
 common.parser.add_argument('-k', '--ack_timeout', type=int, help='ACK timeout in microseconds, accepts [250,4000], step 250', default=250)
-common.parser.add_argument('-r', '--retries', type=int, help='Auto retry limit, accepts [0,15]', default=1, choices=xrange(0, 16), metavar='RETRIES')
+common.parser.add_argument('-r', '--retries', type=int, help='Auto retry limit, accepts [0,15]', default=1, choices=range(0, 16), metavar='RETRIES')
 common.parser.add_argument('-p', '--ping_payload', type=str, help='Ping payload, ex 0F:0F:0F:0F', default='0F:0F:0F:0F', metavar='PING_PAYLOAD')
 common.parse_and_init()
 
 # Parse the address
-address = common.args.address.replace(':', '').decode('hex')[::-1][:5]
+address = codecs.decode(common.args.address.replace(':', ''), 'hex').decode('ascii')[::-1][:5]
 address_string = ':'.join('{:02X}'.format(ord(b)) for b in address[::-1])
 if len(address) < 2:
   raise Exception('Invalid address: {0}'.format(common.args.address))
@@ -42,7 +42,7 @@ common.radio.enter_sniffer_mode(address)
 timeout = float(common.args.timeout) / float(1000)
 
 # Parse the ping payload
-ping_payload = common.args.ping_payload.replace(':', '').decode('hex')
+ping_payload = codecs.decode(common.args.ping_payload.replace(':', ''), 'hex').decode('ascii')
 
 # Format the ACK timeout and auto retry values
 ack_timeout = int(common.args.ack_timeout / 250) - 1


### PR DESCRIPTION
I know it's been a while, since you worked on this, and your PR never got merged for some reason, but I found your fork for python3 support, and I am trying to use it with Logitech Unifiying receiver. I fixed a couple of basic python3 things (in this PR) but am a bit stumped on the bit-twiddling part.

I currently get this:

```
sudo make logitech_install
./prog/usb-flasher/logitech-usb-flash.py bin/dongle.formatted.bin bin/dongle.formatted.ihx
[2022-10-11 14:13:56.618]  Computing the CRC of the firmware image
Traceback (most recent call last):
  File "/home/konsumer/nrf-research-firmware/./prog/usb-flasher/logitech-usb-flash.py", line 25, in <module>
    crc = crc_update(crc, ord(data[x]))
TypeError: ord() expected string of length 1, but int found
make: *** [Makefile:33: logitech_install] Error 1
```

As far as I know, `ord` is not needed because python3 switched how it represents buffers (they are like arrays of numbers, not strings) but if I remove that, other parts of the code rely on it being more like a string. @kripton would you mind taking a look to help me?
